### PR TITLE
Change 'Program Files' to 'Program Files (x86)'

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ started walkthrough for Mac](http://elm-lang.org/onboarding/Mac.elm).
 **Windows** &mdash; use [the installer][windows] and continue the [getting
 started walkthrough for Windows](http://elm-lang.org/onboarding/Windows.elm).
 If you run into issues compiling programs, you may need to manually set your `ELM_HOME`
-environment variable to `C:/Program Files/Elm Platform/0.12.3/share` as reported
+environment variable to `C:/Program Files (x86)/Elm Platform/0.12.3/share` as reported
 [here](https://github.com/elm-lang/elm-platform/issues/2).
 
  [windows]: https://www.dropbox.com/s/qzcm9yyve54ss1l/Elm-Platform-0.12.3.exe


### PR DESCRIPTION
This is what the path is on my Win7 system, and what's mentioned in #2. It also seems like most people are using 64-bit Windows these days, or whatever it is that triggers the x86 variant of the Program Files directory, so I thought it was better to just change it rather than add special instructions for 64-bit Windows.