### PR TITLE
Revert "Check out shallow git copies"

### DIFF
--- a/src/BuildFromSource.hs
+++ b/src/BuildFromSource.hs
@@ -102,7 +102,7 @@ makeRepos artifactDirectory repos =
 makeRepo :: FilePath -> String -> String -> IO ()
 makeRepo root projectName version =
  do  -- get the right version of the repo
-    git [ "clone", "--depth=1", "https://github.com/elm-lang/" ++ projectName ++ ".git" ]
+    git [ "clone", "https://github.com/elm-lang/" ++ projectName ++ ".git" ]
     setCurrentDirectory projectName
     git [ "checkout", version ]
     git [ "pull" ]


### PR DESCRIPTION
This reverts commit 8dfecb9bb0c0b1730cc5139d6355aaf13eee9789.

Fix #23
