### PR TITLE
WIP: Add Homebrew Formula for 0.15.

### DIFF
--- a/installers/mac/homebrew/elm.rb
+++ b/installers/mac/homebrew/elm.rb
@@ -1,0 +1,23 @@
+class Elm < Formula
+  homepage "http://elm-lang.org"
+  url "https://github.com/kevva/elm-bin/raw/v1.4.1/vendor/osx/elm-platform-osx.tar.gz"
+  sha256 "ec94047ca573e66aed5e6ac21ab8656b203bf9e3262f0819dfb35780c3700623"
+  version "0.15"
+
+  def install
+    [
+      "elm",
+      "elm-doc",
+      "elm-make",
+      "elm-package",
+      "elm-reactor",
+      "elm-repl"
+    ].each do |binaryFile|
+      bin.install binaryFile
+    end
+  end
+
+  test do
+    system "elm", "make", "--help"
+  end
+end


### PR DESCRIPTION
I wrote a Homebrew Formula so OS X users can do `brew install elm`. It uses the [elm-bin](https://github.com/kevva/elm-bin) repo for the OS X binaries.

This is WIP because my [pull request into Homebrew](https://github.com/Homebrew/homebrew/pull/39994) is still pending, and the Homebrew folks may request changes to this before they accept it.