### PR TITLE
Build with sandbox sources

### DIFF
--- a/installers/BuildFromSource.hs
+++ b/installers/BuildFromSource.hs
@@ -138,7 +138,10 @@ makeRepos artifactDirectory repos =
     -- install all of the packages together in order to resolve transient dependencies robustly
     -- (install the dependencies a bit more quietly than the elm packages)
     cabal ([ "install", "-j", "--only-dependencies", "--ghc-options=\"-w\"" ] ++ map fst repos)
-    cabal ([ "install", "-j", "--bindir=../", "--ghc-options=\"-XFlexibleContexts\"" ] ++ map fst repos)
+    cabal ([ "install", "-j", "--bindir=../bin", "--ghc-options=\"-XFlexibleContexts\"" ] ++ filter (/= "elm-reactor") (map fst repos))
+
+    -- elm-reactor needs to be installed last because of a post-build dependency on elm-make
+    cabal [ "install", "-j", "--bindir=../", "elm-reactor" ]
 
     return ()
 

--- a/installers/BuildFromSource.hs
+++ b/installers/BuildFromSource.hs
@@ -138,7 +138,7 @@ makeRepos artifactDirectory repos =
     -- install all of the packages together in order to resolve transient dependencies robustly
     -- (install the dependencies a bit more quietly than the elm packages)
     cabal ([ "install", "-j", "--only-dependencies", "--ghc-options=\"-w\"" ] ++ map fst repos)
-    cabal ([ "install", "-j", "--bindir=../" ] ++ map fst repos)
+    cabal ([ "install", "-j", "--bindir=../", "--ghc-options=\"-XFlexibleContexts\"" ] ++ map fst repos)
 
     return ()
 

--- a/installers/BuildFromSource.hs
+++ b/installers/BuildFromSource.hs
@@ -31,14 +31,15 @@ and testing interactions between projects.
 -}
 module Main where
 
-import qualified Data.List as List
-import qualified Data.Map as Map
-import System.Directory (createDirectoryIfMissing, setCurrentDirectory, getCurrentDirectory)
-import System.Environment (getArgs)
-import System.Exit (ExitCode, exitFailure)
-import System.FilePath ((</>))
-import System.IO (hPutStrLn, stderr)
-import System.Process (rawSystem)
+import qualified Data.List          as List
+import qualified Data.Map           as Map
+import           System.Directory   (createDirectoryIfMissing,
+                                     getCurrentDirectory, setCurrentDirectory)
+import           System.Environment (getArgs)
+import           System.Exit        (ExitCode, exitFailure)
+import           System.FilePath    ((</>))
+import           System.IO          (hPutStrLn, stderr)
+import           System.Process     (rawSystem)
 
 
 (=:) = (,)
@@ -134,14 +135,14 @@ makeRepos artifactDirectory repos =
 
     -- add each of the sub-directories as a sandbox source
     cabal ([ "sandbox", "add-source" ] ++ map fst repos)
-    
+
     -- install all of the packages together in order to resolve transitive dependencies robustly
     -- (install the dependencies a bit more quietly than the elm packages)
     cabal ([ "install", "-j", "--only-dependencies", "--ghc-options=\"-w\"" ] ++ map fst repos)
     cabal ([ "install", "-j", "--bindir=../bin", "--ghc-options=\"-XFlexibleContexts\"" ] ++ filter (/= "elm-reactor") (map fst repos))
 
     -- elm-reactor needs to be installed last because of a post-build dependency on elm-make
-    cabal [ "install", "-j", "--bindir=../", "elm-reactor" ]
+    cabal [ "install", "-j", "--bindir=../bin", "elm-reactor" ]
 
     return ()
 

--- a/installers/BuildFromSource.hs
+++ b/installers/BuildFromSource.hs
@@ -148,9 +148,9 @@ makeRepos artifactDirectory repos =
 makeRepo :: FilePath -> String -> String -> IO ()
 makeRepo root projectName version =
   do  -- get the right version of the repo
-    git [ "clone", "https://github.com/elm-lang/" ++ projectName ++ ".git", "--quiet" ]
+    git [ "clone", "https://github.com/elm-lang/" ++ projectName ++ ".git" ]
     setCurrentDirectory projectName
-    git [ "checkout", version ]
+    git [ "checkout", version, "--quiet" ]
     git [ "pull" ]
 
     -- move back into the root

--- a/installers/BuildFromSource.hs
+++ b/installers/BuildFromSource.hs
@@ -135,7 +135,7 @@ makeRepos artifactDirectory repos =
     -- add each of the sub-directories as a sandbox source
     cabal ([ "sandbox", "add-source" ] ++ map fst repos)
     
-    -- install all of the packages together in order to resolve transient dependencies robustly
+    -- install all of the packages together in order to resolve transitive dependencies robustly
     -- (install the dependencies a bit more quietly than the elm packages)
     cabal ([ "install", "-j", "--only-dependencies", "--ghc-options=\"-w\"" ] ++ map fst repos)
     cabal ([ "install", "-j", "--bindir=../bin", "--ghc-options=\"-XFlexibleContexts\"" ] ++ filter (/= "elm-reactor") (map fst repos))


### PR DESCRIPTION
Build the platform from sources using the more robust strategy I mentioned in https://github.com/elm-lang/elm-compiler/issues/995.

(Side note)
--------------
The only trouble I seem to be having is that I don't have `elm-make` in my `$PATH` by the time that I need to build `elm-reactor`:

```
Build log ( /home/rehno/projects/development/elm-platform/installers/Elm-Platform/0.15.1/.cabal-sandbox/logs/elm-reactor-0.3.2.log ):
Configuring elm-reactor-0.3.2...
Building elm-reactor-0.3.2...
Preprocessing executable 'elm-reactor' for elm-reactor-0.3.2...
Linking dist/dist-sandbox-f78d21b8/build/elm-reactor/elm-reactor ...
Custom build step: creating and collecting all static resources
setup: elm-make: does not exist
cabal: Error: some packages failed to install:
elm-reactor-0.3.2 failed during the building phase. The exception was:
ExitFailure 1
```

I'm not sure if this is actually a problem, could you try this install on your local machine @evancz ? I also created a patch to make sure that `elm-reactor` is built last if necessary: https://github.com/rehno-lindeque/elm-platform/compare/build-with-sandboxsources...build-elm-reactor

I was hoping that I could just temporarily change my `PATH` by running the command as
```bash
 PATH=./Elm-Platform/0.15.1/bin:$PATH runhaskell BuildFromSource.hs 0.15.1
```
but it seems as though `Setup.hs` must start on a fresh environment because that didn't do the trick for me.

Anyway, I'm about 95% sure this PR should do the trick (perhaps with https://github.com/rehno-lindeque/elm-platform/compare/build-with-sandboxsources...build-elm-reactor added on).