### PR TITLE
Ignore upper bounds in experimental build script

### DIFF
--- a/versions/0.15.1/build.sh
+++ b/versions/0.15.1/build.sh
@@ -20,7 +20,7 @@ cd elm-package
 git checkout tags/0.5.1 --quiet
 cabal sandbox init --sandbox ../.cabal-sandbox
 cp ../cabal.config .
-cabal install -j --allow-newer
+cabal install -j --allow-newer --ghc-options="-XFlexibleContexts"
 cd ..
 
 

--- a/versions/0.15.1/build.sh
+++ b/versions/0.15.1/build.sh
@@ -11,7 +11,7 @@ cd elm-compiler
 git checkout tags/0.15.1 --quiet
 cabal sandbox init --sandbox ../.cabal-sandbox
 cp ../cabal.config .
-cabal install -j
+cabal install -j --allow-newer
 cd ..
 
 
@@ -20,7 +20,7 @@ cd elm-package
 git checkout tags/0.5.1 --quiet
 cabal sandbox init --sandbox ../.cabal-sandbox
 cp ../cabal.config .
-cabal install -j
+cabal install -j --allow-newer
 cd ..
 
 
@@ -29,7 +29,7 @@ cd elm-make
 git checkout tags/0.2 --quiet
 cabal sandbox init --sandbox ../.cabal-sandbox
 cp ../cabal.config .
-cabal install -j
+cabal install -j --allow-newer
 cd ..
 
 
@@ -38,7 +38,7 @@ cd elm-reactor
 git checkout tags/0.3.2 --quiet
 cabal sandbox init --sandbox ../.cabal-sandbox
 cp ../cabal.config .
-cabal install -j
+cabal install -j --allow-newer
 cd ..
 
 
@@ -47,5 +47,5 @@ cd elm-repl
 git checkout tags/0.4.2 --quiet
 cabal sandbox init --sandbox ../.cabal-sandbox
 cp ../cabal.config .
-cabal install -j
+cabal install -j --allow-newer
 cd ..


### PR DESCRIPTION
This allows the `0.15.1` stuff to be built with GHC 7.10.2 (using the https://www.stackage.org/lts-3.2/cabal.config file).