### PR TITLE
Remove superfluous `git pull`

### DIFF
--- a/installers/BuildFromSource.hs
+++ b/installers/BuildFromSource.hs
@@ -152,7 +152,6 @@ makeRepo root projectName version =
     git [ "clone", "https://github.com/elm-lang/" ++ projectName ++ ".git" ]
     setCurrentDirectory projectName
     git [ "checkout", version, "--quiet" ]
-    git [ "pull" ]
 
     -- move back into the root
     setCurrentDirectory root


### PR DESCRIPTION
That `git pull` leads to surprising "error messages", like here: https://github.com/elm-lang/elm-platform/issues/62#issuecomment-135454405

> You are not currently on a branch. Please specify which
> branch you want to merge with. See git-pull(1) for details.
> 
>     git pull <remote> <branch>

The [commit that introduced that call](https://github.com/elm-lang/elm-platform/commit/1f45bb36a55def2029310f29ba6672fafa2e1ad8) says it was done to make sure to get the latest stuff if it's already checked out. But actually, when that call happens, we have *just a moment before* done a `git clone` to get the repository in the first place. So we do have the latest stuff for sure, don't we?