### PR TITLE
Remove obsolete comment

### DIFF
--- a/installers/BuildFromSource.hs
+++ b/installers/BuildFromSource.hs
@@ -44,8 +44,6 @@ import           System.Process     (rawSystem)
 
 (=:) = (,)
 
--- NOTE: The order of the dependencies is also the build order,
--- so do not just go alphebetizing things.
 configs :: Map.Map String [(String, String)]
 configs =
   Map.fromList


### PR DESCRIPTION
The order there is not relevant anymore. The repos other than `elm-reactor` are built all together, and `elm-reactor` is explicitly built last.