### PR TITLE
Updated instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ First, if you are on Mac or Windows just looking to use Elm, definitely use the 
 
 Second, if you are on some variant of Debian (Ubuntu, Mint, etc.) that happens to be a 64-bit build and just want to use Elm, use [the npm installer](https://www.npmjs.com/package/elm) and be very very attentive to the README there. You need to do that `ELM_HOME` stuff or you will be confused!
 
-Okay, if you have made it here, you are in a unique position. We are currently working on making this smoother in [this issue](https://github.com/elm-lang/elm-platform/issues/60), and and I recommend you read this whole section before you start running anything.
+Okay, if you have made it here, you are in a unique position. We are currently working on making this smoother in [this issue](https://github.com/elm-lang/elm-platform/issues/60), and I recommend you read this whole section before you start running anything.
 
 You will need Haskell to build this stuff. On some platforms the [Haskell Platform][hp] will work for you, but read the rest of this paragraph before making any moves. You need GHC to compile the code. Developers typically build with GHC 7.8 but as of 0.15.1 things should build with GHC 7.10 as well. You also need cabal 1.18 or higher. This will let you create a cabal sandbox which should make the build process much easier. Before getting Haskell Platform, make sure it is going to give you these things.
 
@@ -25,21 +25,18 @@ You will need Haskell to build this stuff. On some platforms the [Haskell Platfo
 
 > **Note:** Sometimes things go bad with cabal, so know that [you can always blow it all up](https://www.reddit.com/r/elm/comments/34np4m/how_to_uninstall_elm/). I sometimes do this after a fresh install of GHC and cabal to make sure there are no globaly installed packages that are going to make things suck for me later.
 
-At this point you should be in a world where your cabal version is greater than 1.18. It probably sucked getting here, so thank you for sticking with this! Now find a directory on your machine where you want the Elm Platform to live. The following commands will download [a script][script] that will create a directory called `Elm-Platform/0.15/*` and build all the necessary things. It is best if you do not have to move `Elm-Platform/` so choose carefully before running:
+At this point you should be in a world where your cabal version is greater than 1.18. It probably sucked getting here, so thank you for sticking with this! Now find a directory on your machine where you want the Elm Platform to live. The following commands will download [a script][script] that will create a directory called `Elm-Platform/0.15.1/*` and build all the necessary things. It is best if you do not have to move `Elm-Platform/`, so choose carefully before progressing. Also, before you run the following, [add to your PATH][add-path] the absolute path to `Elm-Platform/0.15.1/.cabal-sandbox/bin`. This will make it so that all the Elm command line tools are easily available to you later. But it is also required already during the build. So, having set that path, now run:
 
 [script]: https://github.com/elm-lang/elm-platform/blob/master/installers/BuildFromSource.hs
+[add-path]: http://unix.stackexchange.com/questions/26047/how-to-correctly-add-a-path-to-path
 
 ```bash
 # if you are on windows, or some other place without curl, just download this file manually
 curl https://raw.githubusercontent.com/elm-lang/elm-platform/master/installers/BuildFromSource.hs > BuildFromSource.hs
 
-runhaskell BuildFromSource.hs 0.15
+runhaskell BuildFromSource.hs 0.15.1
 ```
 
-> **Note:** You can use the `BuildFromSource.hs` script to build any version of the compiler, so you can run the following to build all the latest versions of things: `runhaskell BuildFromSource.hs master`. Be aware, this is where active development happens, so not everything will be working at all times!
+> **Note:** You can use the `BuildFromSource.hs` script to build any version of the compiler, so you can run the following to build all the latest versions of things: `runhaskell BuildFromSource.hs master`. Be aware, this is where active development happens, so not everything will be working at all times! Also, of course the paths mentioned above need to be adjusted to talk about `master` instead of `0.15.1`.
 
-Once you are done with all this stuff you may want to [add to your PATH][add-path] the absolute path to `Elm-Platform/0.15/.cabal-sandbox/bin`. This will make it so all the Elm command line tools are easily available.
-
-[add-path]: http://unix.stackexchange.com/questions/26047/how-to-correctly-add-a-path-to-path
-
-We have had reports that some people need to set the `ELM_HOME` variable manually to get the debugger working in elm-reactor. If you are having issues like this, you may need to set `ELM_HOME` to something like this `Elm-Platform/0.15/share/x86_64-osx-ghc-7.8.3/elm-reactor-0.3.1/`. It won't be exactly that in your case probably, so go find the equivalent path for your OS and version of elm-reactor.
+We have had reports that some people need to set the `ELM_HOME` variable manually to get the debugger working in elm-reactor. If you are having issues like this, you may need to set `ELM_HOME` to something like `Elm-Platform/0.15.1/.cabal-sandbox/x86_64-osx-ghc-7.8.3/elm-reactor-0.3.2/`. It won't be exactly that in your case probably, so go find the equivalent path for your OS and version of elm-reactor.

--- a/installers/BuildFromSource.hs
+++ b/installers/BuildFromSource.hs
@@ -2,11 +2,14 @@
 Before you use it, make sure you have the Haskell Platform with a recent
 version of cabal.
 
-To install a released version of Elm, run something like this:
+To install a released version of Elm, you will run something like this:
 
     runhaskell BuildFromSource.hs 0.15.1
 
-Whatever directory you run this in, you will now have a new directory for the
+Before you do that, in some directory of your choosing, add
+wherever/Elm-Platform/0.15.1/.cabal-sandbox/bin to your PATH.
+
+Then, run the above. You will now actually have a new directory for the
 Elm Platform, like this:
 
     Elm-Platform/0.15.1/
@@ -15,12 +18,11 @@ Elm Platform, like this:
         ...
         .cabal-sandbox/  -- various build files
 
-All of the executables you need are in .cabal-sandbox/bin/ so add
-wherever/Elm-Platform/0.15.1/.cabal-sandbox/bin to your PATH to use
-them from anywhere.
+All of the executables you need are in .cabal-sandbox/bin, which is on
+your PATH and thus can be used from anywhere.
 
 You can build many versions of the Elm Platform, so it is possible to have
-Elm-Platform/0.15.1/ and Elm-Platform/0.12.3/ with no problems. It is up to you
+Elm-Platform/0.15.1/ and Elm-Platform/0.13/ with no problems. It is up to you
 to manage your PATH variable or symlinks though.
 
 To get set up with the master branch of all Elm Platform projects, run this:


### PR DESCRIPTION
In particular, make sure that people set their `PATH` *before* running the build script (because building `elm-reactor` will need `elm-make`).