### PR TITLE
Add experimental stack-based build system

### DIFF
--- a/versions/0.15.1/stack.yaml
+++ b/versions/0.15.1/stack.yaml
@@ -1,0 +1,29 @@
+flags:
+    blaze-builder-enumerator:
+        newbuilder: False
+packages:
+    - location:
+        git: https://github.com/elm-lang/elm-compiler
+        commit: "0.15.1"
+    - location:
+        git: https://github.com/elm-lang/elm-package
+        commit: "0.5.1"
+    - location:
+        git: https://github.com/elm-lang/elm-make
+        commit: "0.2"
+    - location:
+        git: https://github.com/elm-lang/elm-reactor
+        commit: "0.3.2"
+    - location:
+        git: https://github.com/elm-lang/elm-repl
+        commit: "0.4.2"
+extra-deps:
+    - blaze-builder-0.3.3.4
+    - blaze-builder-enumerator-0.2.1.0
+    - blaze-html-0.7.1.0
+    - blaze-markup-0.6.3.0
+    - fsnotify-0.1.0.3
+    - websockets-snap-0.9.2.0
+resolver: lts-3.2
+ghc-options:
+    elm-package: -XFlexibleContexts

--- a/versions/README.md
+++ b/versions/README.md
@@ -1,0 +1,33 @@
+# Experimental build system
+
+## Getting the latest version of stack
+
+To install the Elm platform from source you will need the latest version of
+[stack](https://github.com/commercialhaskell/stack) from Git. The easiest way
+of accomplishing this is to first:
+
+1. [Install stack](https://github.com/commercialhaskell/stack#how-to-install).
+2. Run `stack upgrade --git`.
+3. Ensure that the old version of stack is no longer on `$PATH`. Running `stack
+   --version` can help you determine this.
+
+## Installing Elm
+
+1. Download the desired `stack.yaml` into an empty directory:
+
+   ```
+   curl https://raw.githubusercontent.com/elm-lang/elm-platform/master/versions/0.15.1/stack.yaml > stack.yaml
+   ```
+
+2. Run the following:
+
+   ```
+   stack install elm-compiler elm-package elm-make elm-repl && stack install elm-reactor
+   ```
+
+   This will install the Elm platform into `~/.local/bin` or its equivalent
+   location on your OS.
+
+3. Optionally delete the directory when done; stack does all its work in a
+   subdirectory named `.stack-work`.
+


### PR DESCRIPTION
This adds support for building elm-platform version 0.15.1 from source using stack. All that's needed is the latest stack (via `stack upgrade --git`) and the 0.15.1 `stack.yaml` file. ~~Then the user simply needs to run `stack install` and everything *should* just work.~~ Then the user needs to either run `stack install --jobs=1` or

```
stack install elm-compiler elm-package elm-make elm-repl && stack install elm-reactor
```

If they don't have the requisite GHC installed (in this case, 7.10), then stack will install the binary for them ~~automatically~~ after they run `stack setup`.