### PR TITLE
Fixes #38 - Windows installer sets PATH "type"

### DIFF
--- a/installers/windows/removefrompath.vbs
+++ b/installers/windows/removefrompath.vbs
@@ -9,4 +9,4 @@ elmBasePath = Replace(Replace(Replace(elmBasePath, "\", "\\"), "(", "\("), ")", 
 regEx.Pattern = elmBasePath & "\\\d+\.\d+(\.\d+|)\\bin(;|)"
 regEx.Global = True
 newPath = regEx.Replace(path, "")
-Call WshShell.RegWrite(PathRegKey, newPath)
+Call WshShell.RegWrite(PathRegKey, newPath, "REG_EXPAND_SZ")

--- a/installers/windows/updatepath.vbs
+++ b/installers/windows/updatepath.vbs
@@ -4,4 +4,4 @@ elmPath = WScript.Arguments(0)
 const PathRegKey = "HKCU\Environment\Path"
 path = WshShell.RegRead(PathRegKey)
 newPath = elmPath & ";" & path
-Call WshShell.RegWrite(PathRegKey, newPath)
+Call WshShell.RegWrite(PathRegKey, newPath, "REG_EXPAND_SZ")


### PR DESCRIPTION
When updating the PATH environment variable, the installer needs to
write REG_EXPAND_SZ type registry keys when persisting an updated
PATH variable so that variables inside the PATH value get
transparently expanded when applications access the PATH variable.

This supports the use case where various directories are stored
in independent *_HOME variables (e.g. JAVA_HOME), and then those
variables are used to build the PATH variable (e.g.
PATH=%JAVA_HOME%\bin;)