### PR TITLE
Move fsnotify constraint to proper place

### DIFF
--- a/installers/BuildFromSource.hs
+++ b/installers/BuildFromSource.hs
@@ -141,11 +141,11 @@ makeRepos artifactDirectory version repos =
 
     -- install all of the packages together in order to resolve transitive dependencies robustly
     -- (install the dependencies a bit more quietly than the elm packages)
-    cabal ([ "install", "-j", "--only-dependencies", "--ghc-options=\"-w\"" ] ++ map fst repos)
+    cabal ([ "install", "-j", "--only-dependencies", "--ghc-options=\"-w\"" ] ++ (if version <= "0.15.1" then [ "--constraint=fsnotify<0.2" ] else []) ++ map fst repos)
     cabal ([ "install", "-j", "--ghc-options=\"-XFlexibleContexts\"" ] ++ filter (/= "elm-reactor") (map fst repos))
 
     -- elm-reactor needs to be installed last because of a post-build dependency on elm-make
-    cabal ([ "install", "-j", "elm-reactor" ] ++ if version <= "0.15.1" then [ "--constraint=fsnotify<0.2" ] else [])
+    cabal [ "install", "-j", "elm-reactor" ]
 
     return ()
 


### PR DESCRIPTION
This is a follow-up of https://github.com/elm-lang/elm-platform/pull/73.

The constraint needs to be enforced already when installing the dependencies. Doing it later, when `elm-reactor` is built, is too late.