### PR TITLE
Require FlexibleContexts only for old versions

### DIFF
--- a/installers/BuildFromSource.hs
+++ b/installers/BuildFromSource.hs
@@ -141,8 +141,12 @@ makeRepos artifactDirectory version repos =
 
     -- install all of the packages together in order to resolve transitive dependencies robustly
     -- (install the dependencies a bit more quietly than the elm packages)
-    cabal ([ "install", "-j", "--only-dependencies", "--ghc-options=\"-w\"" ] ++ (if version <= "0.15.1" then [ "--constraint=fsnotify<0.2" ] else []) ++ map fst repos)
-    cabal ([ "install", "-j", "--ghc-options=\"-XFlexibleContexts\"" ] ++ filter (/= "elm-reactor") (map fst repos))
+    cabal ([ "install", "-j", "--only-dependencies", "--ghc-options=\"-w\"" ]
+           ++ (if version <= "0.15.1" then [ "--constraint=fsnotify<0.2" ] else [])
+           ++ map fst repos)
+    cabal ([ "install", "-j" ]
+           ++ (if version <= "0.15.1" then [ "--ghc-options=\"-XFlexibleContexts\"" ] else [])
+           ++ filter (/= "elm-reactor") (map fst repos))
 
     -- elm-reactor needs to be installed last because of a post-build dependency on elm-make
     cabal [ "install", "-j", "elm-reactor" ]


### PR DESCRIPTION
During a build now, I noticed the only (remaining) requirement for `-XFlexibleContexts` was the one fixed in https://github.com/elm-lang/elm-package/commit/af517f2ffe15f8ec1d8c38f01ce188bbdefea47a. And for the future it seems better to not enable that option in the build script, but instead add type annotations or the language pragma in the sources themselves. (While having the `-XFlexibleContexts` option in the build script might unhelpfully mask such occasions if always on.)