### PR TITLE
Fix issue 34

### DIFF
--- a/installers/windows/removefrompath.vbs
+++ b/installers/windows/removefrompath.vbs
@@ -3,10 +3,15 @@ Set WshShell = CreateObject("WScript.Shell")
 elmBasePath = WScript.Arguments(0)
 'const PathRegKey = "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\Path"
 const PathRegKey = "HKCU\Environment\Path"
+
+on error resume next
 path = WshShell.RegRead(PathRegKey)
-Set regEx = New RegExp
-elmBasePath = Replace(Replace(Replace(elmBasePath, "\", "\\"), "(", "\("), ")", "\)")
-regEx.Pattern = elmBasePath & "\\\d+\.\d+(\.\d+|)\\bin(;|)"
-regEx.Global = True
-newPath = regEx.Replace(path, "")
-Call WshShell.RegWrite(PathRegKey, newPath, "REG_EXPAND_SZ")
+if err.number = 0 then
+	Set regEx = New RegExp
+	elmBasePath = Replace(Replace(Replace(elmBasePath, "\", "\\"), "(", "\("), ")", "\)")
+	regEx.Pattern = elmBasePath & "\\\d+\.\d+(\.\d+|)\\bin(;|)"
+	regEx.Global = True
+	newPath = regEx.Replace(path, "")
+	Call WshShell.RegWrite(PathRegKey, newPath, "REG_EXPAND_SZ")
+end if
+on error goto 0

--- a/installers/windows/updatepath.vbs
+++ b/installers/windows/updatepath.vbs
@@ -5,7 +5,7 @@ const PathRegKey = "HKCU\Environment\Path"
 
 on error resume next
 path = WshShell.RegRead(PathRegKey)
-if err.number = 0 then
+if err.number <> 0 then
 	path = ""
 end if
 on error goto 0

--- a/installers/windows/updatepath.vbs
+++ b/installers/windows/updatepath.vbs
@@ -2,6 +2,13 @@ Set WshShell = CreateObject("WScript.Shell")
 elmPath = WScript.Arguments(0)
 'const PathRegKey = "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\Path"
 const PathRegKey = "HKCU\Environment\Path"
+
+on error resume next
 path = WshShell.RegRead(PathRegKey)
+if err.number = 0 then
+	path = ""
+end if
+on error goto 0
+
 newPath = elmPath & ";" & path
 Call WshShell.RegWrite(PathRegKey, newPath, "REG_EXPAND_SZ")


### PR DESCRIPTION
I've added fixes for [two errors](https://github.com/elm-lang/elm-platform/issues/34) that are experienced by Windows users who do not have a Path environment variable set prior to installing the Elm platform. This issue appears to occur in a wide range of Windows version from Windows 7 to Windows 10 and likely affects users who have recently installed Windows or who haven't installed any applications which have needed to modify the user's path environment variable.