### PR TITLE
Add AppVeyor build for npm installer

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,12 @@
+environment:
+  nodejs_version: "0.10"
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+
+test_script:
+  - node --version
+  - npm --version
+  - npm install installers\npm
+
+build: off

--- a/installers/npm/index.js
+++ b/installers/npm/index.js
@@ -5,9 +5,7 @@ var distDir = path.join("Elm-Platform", platform.elmVersion, ".cabal-sandbox", "
 var paths = {};
 
 platform.executables.forEach(function (executable) {
-    var extension = process.platform === "win32" ? ".exe" : "";
-
-    paths[executable] = path.join(__dirname, distDir, (executable + extension));
+    paths[executable] = path.join(__dirname, distDir, executable);
 });
 
 function getPathTo(executable) {

--- a/installers/npm/platform.js
+++ b/installers/npm/platform.js
@@ -9,6 +9,11 @@ var platformDir = path.join(__dirname, "Elm-Platform", elmVersion);
 var distDir = path.join(platformDir, ".cabal-sandbox", "bin");
 var shareDir = path.join(platformDir, "share");
 var shareReactorDir = path.join(shareDir, "reactor");
+var executables = Object.keys(packageInfo.bin).map(function(executable) {
+    var extension = process.platform === "win32" ? ".exe" : "";
+
+    return executable + extension;
+});
 
 function buildFromSource() {
   return new Promise(function(resolve, reject) {
@@ -39,5 +44,5 @@ module.exports = {
   distDir: distDir,
   shareDir: shareDir,
   shareReactorDir: shareReactorDir,
-  executables: Object.keys(packageInfo.bin)
+  executables: executables
 };


### PR DESCRIPTION
This makes it so we automatically [run win32 builds on AppVeyor](https://ci.appveyor.com/project/rtfeldman/elm-platform) to test that `npm install elm` works on Windows.