### PR TITLE
Have Travis build on OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,5 @@
 sudo: false
 
-language: node_js
-
-node_js:
-  - "stable"
-  - "0.10"
-
 os:
   - linux
   - osx
@@ -19,6 +13,8 @@ addons:
       - cabal-install-1.22
       - happy
       - alex
+      - nodejs
+      - npm
 
 env:
   matrix:
@@ -30,7 +26,7 @@ env:
 
 before_install:
   - if [ ${TRAVIS_OS_NAME} == "osx" ];
-    then brew install ghc; else
+    then brew install node ghc; else
     export PATH=/opt/ghc/7.10.1/bin:/opt/cabal/1.22/bin:$PATH;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,17 +18,17 @@ addons:
 
 env:
   matrix:
-    - export ELM_VERSION=master; export TARGET_NODE_VERSION=stable
-    - export ELM_VERSION=master; export TARGET_NODE_VERSION=0.10
-    - export ELM_VERSION=0.15.1; export TARGET_NODE_VERSION=stable
-    - export ELM_VERSION=0.15.1; export TARGET_NODE_VERSION=0.10
+    - ELM_VERSION=master TARGET_NODE_VERSION=stable
+    - ELM_VERSION=master TARGET_NODE_VERSION=0.10
+    - ELM_VERSION=0.15.1 TARGET_NODE_VERSION=stable
+    - ELM_VERSION=0.15.1 TARGET_NODE_VERSION=0.10
 
   global:
     - secure: "RY4A5Bj0tN7rscwPh6eDJUmf2qWW6lXPBQrD74vg3hB1ubloCRuoXvBD8evUSQg6Kb1D7Dqi3FNpZmt9In7Tiz3Xy6Vb4Q0pbh1r8rq97ZuFFbxzPVRL2QuyYuqQfvsfoal4NVxGyhfTaLh1tCC/G6CjCjGDRXFcqhcz+CR0cEI="
 
 before_install:
   - if [ ${TRAVIS_OS_NAME} == "osx" ];
-    then brew install node ghc; else
+    then brew update && brew install ghc; else
     export PATH=/opt/ghc/7.10.1/bin:/opt/cabal/1.22/bin:$PATH;
     fi
   - npm install -g nvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 
 os:
-  - linux
   - osx
+  - linux
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,10 @@ addons:
 
 env:
   matrix:
-    - ELM_VERSION=master
-    - ELM_VERSION=0.15.1
+    - export ELM_VERSION=master; export TARGET_NODE_VERSION=stable
+    - export ELM_VERSION=master; export TARGET_NODE_VERSION=0.10
+    - export ELM_VERSION=0.15.1; export TARGET_NODE_VERSION=stable
+    - export ELM_VERSION=0.15.1; export TARGET_NODE_VERSION=0.10
 
   global:
     - secure: "RY4A5Bj0tN7rscwPh6eDJUmf2qWW6lXPBQrD74vg3hB1ubloCRuoXvBD8evUSQg6Kb1D7Dqi3FNpZmt9In7Tiz3Xy6Vb4Q0pbh1r8rq97ZuFFbxzPVRL2QuyYuqQfvsfoal4NVxGyhfTaLh1tCC/G6CjCjGDRXFcqhcz+CR0cEI="
@@ -29,6 +31,9 @@ before_install:
     then brew install node ghc; else
     export PATH=/opt/ghc/7.10.1/bin:/opt/cabal/1.22/bin:$PATH;
     fi
+  - npm install -g nvm
+  - export PATH=./node_modules/.bin:$PATH
+  - nvm install $TARGET_NODE_VERSION
 
 install:
   - travis_retry cabal update

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ addons:
 
 env:
   matrix:
-    - ELM_VERSION=master TARGET_NODE_VERSION=stable
+    - ELM_VERSION=master TARGET_NODE_VERSION=node
     - ELM_VERSION=master TARGET_NODE_VERSION=0.10
-    - ELM_VERSION=0.15.1 TARGET_NODE_VERSION=stable
+    - ELM_VERSION=0.15.1 TARGET_NODE_VERSION=node
     - ELM_VERSION=0.15.1 TARGET_NODE_VERSION=0.10
 
   global:
@@ -28,14 +28,13 @@ env:
 
 before_install:
   - if [ ${TRAVIS_OS_NAME} == "osx" ];
-    then brew update && brew install ghc; else
-    export PATH=/opt/ghc/7.10.1/bin:/opt/cabal/1.22/bin:$PATH;
+    then brew update; brew install cabal-install; brew install nvm; mkdir ~/.nvm; export NVM_DIR=~/.nvm; source $(brew --prefix nvm)/nvm.sh; else
+    export PATH=/opt/ghc/7.10.1/bin:/opt/cabal/1.22/bin:$PATH; curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.29.0/install.sh | bash;
     fi
-  - npm install -g nvm
-  - export PATH=./node_modules/.bin:$PATH
-  - nvm install $TARGET_NODE_VERSION
 
 install:
+  - nvm install $TARGET_NODE_VERSION
+  - nvm use $TARGET_NODE_VERSION
   - travis_retry cabal update
   - cd installers/npm
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ node_js:
   - "stable"
   - "0.10"
 
+os:
+  - linux
+  - osx
+
 addons:
   apt:
     sources:
@@ -25,7 +29,10 @@ env:
     - secure: "RY4A5Bj0tN7rscwPh6eDJUmf2qWW6lXPBQrD74vg3hB1ubloCRuoXvBD8evUSQg6Kb1D7Dqi3FNpZmt9In7Tiz3Xy6Vb4Q0pbh1r8rq97ZuFFbxzPVRL2QuyYuqQfvsfoal4NVxGyhfTaLh1tCC/G6CjCjGDRXFcqhcz+CR0cEI="
 
 before_install:
-  - export PATH=/opt/ghc/7.10.1/bin:/opt/cabal/1.22/bin:$PATH
+  - if [ ${TRAVIS_OS_NAME} == "osx" ];
+    then brew install ghc; else
+    export PATH=/opt/ghc/7.10.1/bin:/opt/cabal/1.22/bin:$PATH;
+    fi
 
 install:
   - travis_retry cabal update

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm",
-  "version": "0.15.1-beta4",
+  "version": "0.15.1+revision2",
   "description": "The Elm Platform: Binaries for the Elm programming language.",
   "preferGlobal": true,
   "license": "BSD-3-Clause",


### PR DESCRIPTION
Changes:
* Build on OS X in addition to Linux
* Instead of using `language: nodejs` and the versions `stable` and `0.10`, use only the latest version and install it via `apt-get` in the case of `linux` and via `brew` in the case of `osx`.