### PR TITLE
Update Travis to publish per-OS binary names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,10 @@ install:
   - npm install
 
 before_script:
+  - if [ ${TRAVIS_OS_NAME} == "osx" ];
+    then export BINARY_OS_NAME=darwin; else
+    export BINARY_OS_NAME=$TRAVIS_OS_NAME;
+    fi
   - cd ..
 
 script:
@@ -59,4 +63,4 @@ script:
   - mkdir dist_binaries
   - cp .cabal-sandbox/bin/elm* dist_binaries
   - tar cvzf binaries.tar.gz dist_binaries
-  - curl -T binaries.tar.gz -uelmtravis:$BINTRAY_API_KEY https://api.bintray.com/content/elmlang/elm-platform/npm/$ELM_VERSION/$ELM_VERSION/linux-x64.tar.gz
+  - curl -T binaries.tar.gz -uelmtravis:$BINTRAY_API_KEY https://api.bintray.com/content/elmlang/elm-platform/npm/$ELM_VERSION/$ELM_VERSION/$BINARY_OS_NAME-x64.tar.gz


### PR DESCRIPTION
So we get both a `darwin-x64.tar.gz` as well as a `linux-64.tar.gz`