### PR TITLE
Uses `request` package for npm installation; works behind proxy servers

### DIFF
--- a/installers/npm/README.md
+++ b/installers/npm/README.md
@@ -11,6 +11,22 @@ Run this to get the binaries:
 $ npm install -g elm
 ```
 
+## Installing behind a proxy server
+
+If you are behind a proxy server, set the environment variable "HTTPS_PROXY".
+
+```
+$ export HTTPS_PROXY=$YourProxyServer$
+$ npm install -g elm
+```
+
+Or on Windows:
+
+```
+$ set HTTPS_PROXY=$YourProxyServer$
+$ npm install -g elm
+```
+
 ## Troubleshooting
 
 1. [Troubleshooting npm](https://github.com/npm/npm/wiki/Troubleshooting)

--- a/installers/npm/install.js
+++ b/installers/npm/install.js
@@ -1,15 +1,17 @@
 var Promise = require("promise");
 var path = require("path");
 var platform = require(path.join(__dirname, "platform"));
-var spawn = require("child_process").spawn;
-var path = require("path");
 var fs = require("fs");
-var https = require("follow-redirects").https;
+var request = require("request");
 var tar = require("tar");
 var zlib = require("zlib");
 var mkdirp = require("mkdirp");
 var distDir = platform.distDir;
 var shareReactorDir = platform.shareReactorDir;
+
+if(process.env.https_proxy) {
+  request = request.defaults({"proxy": process.env.https_proxy});
+}
 
 function checkBinariesPresent() {
   return Promise.all(
@@ -43,9 +45,53 @@ function downloadBinaries() {
     var url = "https://dl.bintray.com/elmlang/elm-platform/"
       + platform.elmVersion + "/" + filename;
 
-    https.get(url, function(response) {
+    var untar = tar.Extract({path: distDir, strip: 1})
+        .on("error", function(error) {
+          reject("Error extracting " + filename + " - " + error);
+        })
+        .on("end", function() {
+          if (!fs.existsSync(distDir)) {
+            reject(
+                "Error extracting executables: extraction finished, but",
+                distDir, "directory was not created.\n" +
+                "Current directory contents: " + fs.readdirSync(__dirname)
+            );
+          }
+
+          if (!fs.statSync(distDir).isDirectory()) {
+            reject(
+                "Error extracting executables: extraction finished, but" +
+                distDir + "ended up being a file, not a directory. " +
+                "This can happen when the .tar.gz file contained the " +
+                "binaries directly, instead of containing a directory with " +
+                "the files inside.");
+          }
+
+          checkBinariesPresent().then(function() {
+                resolve("Successfully downloaded and processed " + filename);
+              }, function(error) {
+                console.error("Error extracting executables...");
+                console.error("Expected these executables to be in", distDir, " - ", platform.executables);
+                console.error("...but got these contents instead:", fs.readdirSync(distDir));
+
+                reject(error);
+              }
+          );
+        });
+
+    var gunzip = zlib.createGunzip()
+        .on("error", function(error) {
+          reject("Error decompressing " + filename + " " + error);
+        });
+
+    request.get(url, function(error, response) {
+      if(error) {
+        reject("Error communicating with URL " + url + " " + error);
+        return;
+      }
       if (response.statusCode == 404) {
         reject("Unfortunately, there are currently no Elm Platform binaries available for your operating system and architecture.\n\nIf you would like to build Elm from source, there are instructions at https://github.com/elm-lang/elm-platform#build-from-source\n");
+        return;
       }
 
       if (!fs.existsSync(distDir)) {
@@ -54,51 +100,10 @@ function downloadBinaries() {
 
       console.log("Downloading Elm binaries from " + url);
 
-      var untar = tar.Extract({path: distDir, strip: 1})
-        .on("error", function(error) {
-          reject("Error extracting " + filename + " - " + error);
-        })
-        .on("end", function() {
-          if (!fs.existsSync(distDir)) {
-            reject(
-              "Error extracting executables: extraction finished, but",
-              distDir, "directory was not created.\n" +
-              "Current directory contents: " + fs.readdirSync(__dirname)
-            );
-          }
-
-          if (!fs.statSync(distDir).isDirectory()) {
-            reject(
-              "Error extracting executables: extraction finished, but" +
-              distDir + "ended up being a file, not a directory. " +
-              "This can happen when the .tar.gz file contained the " +
-              "binaries directly, instead of containing a directory with " +
-              "the files inside.");
-          }
-
-          checkBinariesPresent().then(function() {
-              resolve("Successfully downloaded and processed " + filename);
-            }, function(error) {
-              console.error("Error extracting executables...");
-              console.error("Expected these executables to be in", distDir, " - ", platform.executables);
-              console.error("...but got these contents instead:", fs.readdirSync(distDir));
-
-              reject(error);
-            }
-          );
-        });
-
-      var gunzip = zlib.createGunzip()
-        .on("error", function(error) {
-          reject("Error decompressing " + filename + " " + error);
-        });
-
       response.on("error", function(error) {
         reject("Error receiving " + url);
-      }).pipe(gunzip).pipe(untar);
-    }).on("error", function(error) {
-      reject("Error communicating with URL " + url + " " + error);
-    });
+      });
+    }).pipe(gunzip).pipe(untar);
   });
 }
 
@@ -108,51 +113,53 @@ function downloadReactorAssets() {
     + platform.elmVersion + "/" + filename;
 
   return new Promise(function(resolve, reject) {
-    https.get(url, function(response) {
-      if (response.statusCode != 200 && response.statusCode != 204) {
-        console.log("Unable to download elm-reactor assets. elm-reactor may not work properly.");
-
-        reject(response.statusCode);
-
-        return;
-      }
-
-      console.log("Downloading Elm Reactor assets from " + url);
-
-      var untar = tar.Extract({path: shareReactorDir, strip: 1})
+    var untar = tar.Extract({path: shareReactorDir, strip: 1})
         .on("error", function(error) {
           reject("Error extracting " + filename + " - " + error);
         })
         .on("end", function() {
           if (!fs.existsSync(shareReactorDir)) {
             reject(
-              "Error extracting elm-reactor assets: extraction finished, but",
-              distDir, "directory was not created.\n" +
-              "Current directory contents: " + fs.readdirSync(__dirname)
+                "Error extracting elm-reactor assets: extraction finished, but",
+                distDir, "directory was not created.\n" +
+                "Current directory contents: " + fs.readdirSync(__dirname)
             );
           }
 
           if (!fs.statSync(shareReactorDir).isDirectory()) {
             reject(
-              "Error extracting elm-reactor assets: extraction finished, but" +
-              distDir + "ended up being a file, not a directory. " +
-              "This can happen when the .tar.gz file contained the " +
-              "assets directly, instead of containing a directory with " +
-              "the files inside.");
+                "Error extracting elm-reactor assets: extraction finished, but" +
+                distDir + "ended up being a file, not a directory. " +
+                "This can happen when the .tar.gz file contained the " +
+                "assets directly, instead of containing a directory with " +
+                "the files inside.");
           }
 
           resolve("Successfully downloaded and processed " + filename);
         });
 
-      var gunzip = zlib.createGunzip()
+    var gunzip = zlib.createGunzip()
         .on("error", function(error) {
           reject("Error decompressing " + filename + " " + error);
         });
 
+    request.get(url, function(error, response) {
+      if(error) {
+        reject("Error communicating with URL " + url + " " + error);
+        return;
+      }
+      if (response.statusCode != 200 && response.statusCode != 204) {
+        console.log("Unable to download elm-reactor assets. elm-reactor may not work properly.");
+        reject(response.statusCode);
+        return;
+      }
+
+      console.log("Downloading Elm Reactor assets from " + url);
+
       response.on("error", function(error) {
         reject("Error receiving " + url);
-      }).pipe(gunzip).pipe(untar);
-    });
+      });
+    }).pipe(gunzip).pipe(untar);
   });
 }
 

--- a/installers/npm/package.json
+++ b/installers/npm/package.json
@@ -48,9 +48,9 @@
     "elm-repl": "binwrappers/elm-repl"
   },
   "dependencies": {
-    "follow-redirects": "0.0.7",
     "mkdirp": "0.5.1",
     "promise": "7.0.4",
-    "tar": "2.2.1"
+    "tar": "2.2.1",
+    "request": "2.69.0"
   }
 }


### PR DESCRIPTION
As mentioned in #125 the npm installer does not work behind proxy servers, e.g. on corporate developer machines.

This PR uses the [request](https://www.npmjs.com/package/request) npm package instead of [follow-redirects](https://www.npmjs.com/package/follow-redirects) which allows configuring a proxy. The proxy server is taken from the environment variable HTTPS_PROXY, examples were included in the README.

I hope the request package allows the same functionality as the follow-redirects package, the installation worked both on a Linux machine and a Windows machine where I have to use a proxy.

Notes on the rather big change:
Piping on the response object did not work anymore and had to be done directly on the `request.get` call, therefore the tar and gunzip functions were moved one level higher.