### PR TITLE
Removed unnecessary proxy env handling

### DIFF
--- a/installers/npm/install.js
+++ b/installers/npm/install.js
@@ -9,10 +9,6 @@ var mkdirp = require("mkdirp");
 var distDir = platform.distDir;
 var shareReactorDir = platform.shareReactorDir;
 
-if(process.env.https_proxy) {
-  request = request.defaults({"proxy": process.env.https_proxy});
-}
-
 function checkBinariesPresent() {
   return Promise.all(
     platform.executables.map(function(executable) {


### PR DESCRIPTION
The request module handles environment http_proxy / https_proxy variables and the upper case variants automatically by default (See https://github.com/request/request#controlling-proxy-behaviour-using-environment-variables). I removed the unnecessary code. Related to my comment on #130