### PR TITLE
typo

### DIFF
--- a/upgrade-docs/0.17.md
+++ b/upgrade-docs/0.17.md
@@ -102,7 +102,7 @@ view model =
     ]
 ```
 
-This change is pretty simple. Any occurance of `address` just gets deleted. In the types, you see the addresses removed, and `Html` becomes `Html Msg`. You can read `Html Msg` as "an HTML node that can produces messages of type `Msg`". This change makes addresses unnecessary and makes it much clearer what kind of messages can be produced by a particular block of HTML.
+This change is pretty simple. Any occurance of `address` just gets deleted. In the types, you see the addresses removed, and `Html` becomes `Html Msg`. You can read `Html Msg` as "an HTML node that can produce messages of type `Msg`". This change makes addresses unnecessary and makes it much clearer what kind of messages can be produced by a particular block of HTML.
 
 The `Signal.forwardTo` function is replaced by `Html.App.map`. So you may need to make changes like this:
 


### PR DESCRIPTION
removed the extra 's' in the following sentence: an HTML node that can produces messages of type `Msg`