### PR TITLE
Add shallow clone option to git clone

### DIFF
--- a/installers/BuildFromSource.hs
+++ b/installers/BuildFromSource.hs
@@ -205,7 +205,7 @@ makeRepos artifactDirectory version repos =
 makeRepo :: FilePath -> String -> String -> IO ()
 makeRepo root projectName version =
   do  -- get the right version of the repo
-      git [ "clone", "https://github.com/elm-lang/" ++ projectName ++ ".git" ]
+      git [ "clone", "--depth", "1", "--no-single-branch", "https://github.com/elm-lang/" ++ projectName ++ ".git" ]
       setCurrentDirectory projectName
       git [ "checkout", version, "--quiet" ]
 


### PR DESCRIPTION
shallow clone can make faster than unshallow clone(fetching all histories of HEAD).
Add options "--depth <depth>", "--no-single-branch" to clone elm repos.

- "--depth <depth>" create shallow clone with a history truncated to <depth> of revisions.
- "--no-single-branch" fetch the histories near the tips of all branches.