### PR TITLE
Update README.md to warn of using cabal 1.22.5, which is very buggy

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ There are two phases!
 
 #### 1. Get Haskell Working
 
-You will need Haskell to build this stuff. On some platforms the [Haskell Platform][hp] will work for you, but read the rest of this paragraph before making any moves. You need GHC to compile the code. Developers typically build with GHC 7.10 but Elm versions before 0.16 should build with GHC 7.8 as well. You also need cabal 1.18 or higher. This will let you create a cabal sandbox which should make the build process much easier. Before getting Haskell Platform, [make sure it is going to give you these things](https://www.haskell.org/platform/contents.html).
+You will need Haskell to build this stuff. On some platforms the [Haskell Platform][hp] will work for you, but read the rest of this paragraph before making any moves. You need GHC to compile the code. Developers typically build with GHC 7.10 but Elm versions before 0.16 should build with GHC 7.8 as well. You also need cabal 1.18 or higher. (Don't use cabal 1.22.5, since it has a major bug. Use 1.22.6 or higher instead.) This will let you create a cabal sandbox which should make the build process much easier. Before getting Haskell Platform, [make sure it is going to give you these things](https://www.haskell.org/platform/contents.html).
 
 [hp]: http://hackage.haskell.org/platform/
 


### PR DESCRIPTION
Add a note on cabal-1.22.5, which seems to be prone to errors when installing packages. I used 1.22.5, since it is in the matrix of the Haskell Platform for the latest GHC 7.10 release, hence it was my preferred choice.
It didn't work at all on my fresh setup on a Raspberry Pi and updating to cabal-1.22.9 solved the problem for me. Answers on github bugs and Stack Overflow suggest that the relevant fix is already included in cabal 1.22.6 - see https://github.com/haskell/cabal/issues/2663.
  